### PR TITLE
PHP7 Compatibility

### DIFF
--- a/curve.c
+++ b/curve.c
@@ -3,6 +3,10 @@
 #endif
 
 #include "php.h"
+#include "php_curve25519.h"
+#include "ext/standard/info.h"
+#include "zend_exceptions.h"
+#include "ext/spl/spl_exceptions.h"
 
 const unsigned char basepoint[32] = {9};
 
@@ -13,115 +17,205 @@ void curve25519_clamp(unsigned char secret[32])
 	secret[31] |= 64;
 }
 
-PHP_FUNCTION(curve25519_sign){
-    const char *random;
+PHP_FUNCTION(curve25519_sign)
+{
+    char *random;
+    char *privatekey;
+    char *message;
+
+#if PHP_VERSION_ID >= 70000
+    size_t random_len;
+    size_t private_len;
+    size_t message_len;
+#else
     int random_len;
-    const char *privatekey;
     int private_len;
-    const char *message;
     int message_len;
+#endif 
+
     char signature[64];
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss", &random, &random_len,&privatekey,&private_len,&message,&message_len) == FAILURE) {
-		RETURN_FALSE;
-	}
-	if (private_len != 32) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Private must be 32 bytes");
-		RETURN_FALSE
-	}
-    if (random_len != 64) {
-        php_error_docref(NULL TSRMLS_CC,E_WARNING, "Random must be 64-byte string");
-        RETURN_FALSE
+
+#ifndef FAST_ZPP
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss", &random, &random_len, &privatekey, &private_len, &message, &message_len) == FAILURE) {
+        RETURN_FALSE;
     }
+#else
+    ZEND_PARSE_PARAMETERS_START(3, 3)
+        Z_PARAM_STRING(random, random_len)
+        Z_PARAM_STRING(privatekey, private_len)
+        Z_PARAM_STRING(message, message_len)
+    ZEND_PARSE_PARAMETERS_END();
+#endif
+
+    if (private_len != 32) {
+        zend_throw_exception(spl_ce_InvalidArgumentException, "Private key must be 32 bytes", 0 TSRMLS_CC);
+    }
+
+    if (random_len != 64) {
+        zend_throw_exception(spl_ce_InvalidArgumentException, "Random must be 64-byte string", 0 TSRMLS_CC);
+    }
+
  	curve25519_sign((unsigned char *)signature, (unsigned char *)privatekey, 
                     (unsigned char *)message, message_len, (unsigned char *)random);
- 	RETURN_STRINGL((char*)signature, 64,1);
+
+#if PHP_VERSION_ID >= 70000
+    RETURN_STRINGL((char*)signature, 64);
+#else
+    RETURN_STRINGL((char*)signature, 64, 1);
+#endif  
 }
-PHP_FUNCTION(curve25519_verify){
-    const char *publickey;
+
+PHP_FUNCTION(curve25519_verify)
+{
+    char *publickey;
+    char *message;
+    char *signature;
+
+#if PHP_VERSION_ID >= 70000
+    size_t public_len;
+    size_t message_len;
+    size_t signature_len;
+#else
     unsigned int public_len;
-    const char *message;
     unsigned int message_len;
-    const char *signature;
     unsigned int signature_len;
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss", &publickey, &public_len,&message,&message_len,&signature,&signature_len) == FAILURE) {
-		RETURN_FALSE;
-	}	
-	if (public_len != 32) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Public must be 32 bytes");
-		RETURN_FALSE
-	}
-    if (signature_len != 64) {
-        php_error_docref(NULL TSRMLS_CC,E_WARNING, "Signature must be 64-byte string");
-        RETURN_FALSE
+#endif  
+
+#ifndef FAST_ZPP
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss", &publickey, &public_len, &message, &message_len, &signature, &signature_len) == FAILURE) {
+        RETURN_FALSE;
     }
+#else
+    ZEND_PARSE_PARAMETERS_START(3, 3)
+        Z_PARAM_STRING(publickey, public_len)
+        Z_PARAM_STRING(message, message_len)
+        Z_PARAM_STRING(signature, signature_len)   
+    ZEND_PARSE_PARAMETERS_END();
+#endif
+
+    if (public_len != 32) {
+        zend_throw_exception(spl_ce_InvalidArgumentException, "Public must be 32 bytes", 0 TSRMLS_CC);
+    }
+
+    if (signature_len != 64) {
+        zend_throw_exception(spl_ce_InvalidArgumentException, "Signature must be 64-byte string", 0 TSRMLS_CC);
+    }
+
     int result = curve25519_verify((unsigned char *)signature, (unsigned char *)publickey, 
                                    (unsigned char *)message, message_len);
     RETURN_LONG(result);
 }
-PHP_FUNCTION(curve25519_private){
-	unsigned char *random;
-	int random_len;
 
+PHP_FUNCTION(curve25519_private)
+{
+	char *random;
+
+#if PHP_VERSION_ID >= 70000
+    size_t random_len;
+#else
+    int random_len;
+#endif  
+
+#ifndef FAST_ZPP
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &random, &random_len) == FAILURE) {
-		RETURN_FALSE;
-	}	
+        RETURN_FALSE;
+    }
+#else
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(random, random_len)
+    ZEND_PARSE_PARAMETERS_END();
+#endif
+
 	if (random_len != 32) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Random must be 32 bytes");
-		RETURN_FALSE
-	}
+        zend_throw_exception(spl_ce_InvalidArgumentException, "Random must be 32-byte string", 0 TSRMLS_CC);
+    }
+
 	random[0] &= 248;
     random[31] &= 127;
     random[31] |= 64;
 
+#if PHP_VERSION_ID >= 70000
+    RETURN_STRINGL(random, 32);
+#else
     RETURN_STRINGL(random, 32, 1);
+#endif  
 }
 
 PHP_FUNCTION(curve25519_public)
 {
-	const char *private;
-	int private_len;
+	char *private;
+#if PHP_VERSION_ID >= 70000
+    size_t private_len;
+#else
+    int private_len;
+#endif 
+
     char basepoint[32] = {9};
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &private, &private_len) == FAILURE) {
-		RETURN_FALSE;
-	}
+
+#ifndef FAST_ZPP
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &private, &private_len) == FAILURE) {
+        RETURN_FALSE;
+    }
+#else
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(private, private_len)
+    ZEND_PARSE_PARAMETERS_END();
+#endif
 
 	if (private_len != 32) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Private must be 32 bytes");
-		RETURN_FALSE
-	}
+        zend_throw_exception(spl_ce_InvalidArgumentException, "Private key must be 32 bytes", 0 TSRMLS_CC);
+    }
 
 	char public[32];
 	curve25519_donna(public, private, basepoint);
 
-
-	RETURN_STRINGL((char*)public, 32, 1);
+#if PHP_VERSION_ID >= 70000
+    RETURN_STRINGL((char*)public, 32);
+#else
+    RETURN_STRINGL((char*)public, 32, 1);
+#endif  
 }
 
 PHP_FUNCTION(curve25519_shared)
 {
-	const char *private;
-	int private_len;
+    char *private;
+    char *public;
 
-	const char *public;
-	int public_len;
+#if PHP_VERSION_ID >= 70000
+    size_t private_len;
+    size_t public_len;
+#else
+    int private_len;
+    int public_len;
+#endif 
 
-
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss", &private, &private_len, &public, &public_len) == FAILURE) {
-		RETURN_FALSE;
-	}
+#ifndef FAST_ZPP
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss", &private, &private_len, &public, &public_len) == FAILURE) {
+        RETURN_FALSE;
+    }
+#else
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(private, private_len)
+        Z_PARAM_STRING(public, public_len)
+    ZEND_PARSE_PARAMETERS_END();
+#endif
 
 	if (private_len != 32) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Private must be 32 bytes");
-		RETURN_FALSE;
-	}
+        zend_throw_exception(spl_ce_InvalidArgumentException, "Private key must be 32 bytes", 0 TSRMLS_CC);
+    }
 
 	if (public_len != 32) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Public must be 32 bytes");
-		RETURN_FALSE;
-	}
+        zend_throw_exception(spl_ce_InvalidArgumentException, "Public must be 32 bytes", 0 TSRMLS_CC);
+    }
+
 	char shared_key[32];
 	curve25519_donna(shared_key, private, public);
-	RETURN_STRINGL(shared_key, 32, 1);
+
+#if PHP_VERSION_ID >= 70000
+    RETURN_STRINGL(shared_key, 32);
+#else
+    RETURN_STRINGL(shared_key, 32, 1);
+#endif  
 }
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_curve25519_sign, 0, 0, 1)

--- a/php_curve25519.h
+++ b/php_curve25519.h
@@ -1,0 +1,4 @@
+extern zend_module_entry curve25519_module_entry;
+
+#define curve25519_module_ptr &curve25519_module_entry
+#define phpext_curve25519_ptr curve25519_module_ptr


### PR DESCRIPTION
Hi,

Thanks for creating this! The following merge request enables PHP7 support for this extension while still maintaining support for PHP 5.6.

```
PHP7 Compatibility

    - Allows compilation on PHP 7, PHP 5.6
    - Adds support to be compiled directly into PHP

 Code improvements

    - Refactoring of PHP7 changes
    - Adding spl_ce_InvalidArgumentException exceptions for invalid parameter types
    - Implementing FAST_ZPP: https://wiki.php.net/rfc/fast_zpp
```

Please let me know if there are any issues or you'd like to see any additional changes as part of this merge request.
