### PR TITLE
add configuration file for compile on windows

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,0 +1,8 @@
+ARG_ENABLE('curve25519', 'curve25519 support', 'no');
+
+if (PHP_CURVE25519 != 'no') {
+    AC_DEFINE('HAVE_CURVE25519', 1, 'Whether you have curve25519 extension');
+
+    EXTENSION('curve25519', 'curve.c', true);
+    ADD_SOURCES(configure_module_dirname, 'curve\\curve25519-donna.c curve\\ed25519\\*.c curve\\ed25519\\additions\\*.c curve\\ed25519\\nacl_sha512\\*.c', 'curve25519');
+}


### PR DESCRIPTION
config.w32 is configuration file for compile on windows.

we can compile this library on windows now.